### PR TITLE
Automatically package plugin for each release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,10 @@ version: 2.1
 workflows:
   main:
     jobs:
-      - build
+      - build:
+          filters:
+            tags:
+              only: /.*/
       - unit-php71:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,7 @@ jobs:
 
   package:
     docker:
-      - image: circleci/php7.3-node
+      - image: circleci/golang:latest
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,8 +177,6 @@ jobs:
       - run:
           name: "Upload the package to GitHub"
           command: ghr -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -n "Version ${CIRCLE_TAG}" ${CIRCLE_TAG} skaut-google-drive-gallery.${CIRCLE_TAG}.zip
-      - store_artifacts:
-          path: skaut-google-drive-gallery.${CIRCLE_TAG}.zip
 
   lint:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,8 @@ workflows:
       - platform-check
       - package:
           filters:
+            branches:
+              only:
             tags:
               only: /.*/
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,9 @@ workflows:
             - build
           coverage: true
       - platform-check
+      - package:
+          requires:
+            - build
       - lint:
           requires:
             - build
@@ -147,6 +150,21 @@ jobs:
       - run:
           name: "Check platform reqs"
           command: composer check-platform-reqs --no-dev
+
+  package:
+    docker:
+      - image: circleci/php7.3-node
+    steps:
+      - checkout
+      - attach_workspace:
+          at: dist
+      - run:
+          name: "Create zip"
+          command: |
+            cp -r dist skaut-google-drive-gallery
+            zip -r skaut-google-drive-gallery.$CIRCLE_TAG.zip skaut-google-drive-gallery
+      - store_artifacts:
+          path: skaut-google-drive-gallery.$CIRCLE_TAG.zip
 
   lint:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ workflows:
       - package:
           filters:
             branches:
-              only:
+              ignore: /.*/
             tags:
               only: /.*/
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,9 @@ workflows:
           coverage: true
       - platform-check
       - package:
+          filters:
+            tags:
+              only: /.*/
           requires:
             - build
       - lint:
@@ -159,12 +162,18 @@ jobs:
       - attach_workspace:
           at: dist
       - run:
-          name: "Create zip"
+          name: "Install ghr"
+          command: go get github.com/tcnksm/ghr
+      - run:
+          name: "Create zip package"
           command: |
             cp -r dist skaut-google-drive-gallery
-            zip -r skaut-google-drive-gallery.$CIRCLE_TAG.zip skaut-google-drive-gallery
+            zip -r skaut-google-drive-gallery.${CIRCLE_TAG}.zip skaut-google-drive-gallery
+      - run:
+          name: "Upload the package to GitHub"
+          command: ghr -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -n "Version ${CIRCLE_TAG}" ${CIRCLE_TAG} skaut-google-drive-gallery.${CIRCLE_TAG}.zip
       - store_artifacts:
-          path: skaut-google-drive-gallery.$CIRCLE_TAG.zip
+          path: skaut-google-drive-gallery.${CIRCLE_TAG}.zip
 
   lint:
     docker:


### PR DESCRIPTION
From now on, when a tag is pushed to the repo, the CI will automatically package the plugin, create a GitHub release and attach the zipped plugin so that @kalich5 can upload it to WP.org.