### PR TITLE
Removed eslint-config-wordpress

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2714,12 +2714,6 @@
         }
       }
     },
-    "eslint-config-wordpress": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-wordpress/-/eslint-config-wordpress-2.0.0.tgz",
-      "integrity": "sha1-UgEgbGlk1kgxUjLt9t+9LpJeTNY=",
-      "dev": true
-    },
     "eslint-plugin-compat": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-compat/-/eslint-plugin-compat-3.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "@typescript-eslint/parser": "^2.7.0",
     "@wordpress/eslint-plugin": "^3.2.0",
     "eslint": "^6.6.0",
-    "eslint-config-wordpress": "^2.0.0",
     "eslint-plugin-compat": "^3.3.0",
     "gulp": "^4.0.2",
     "gulp-clean-css": "^4.2.0",


### PR DESCRIPTION
It is deprecated and fully replaced by `@wordpress/eslint-plugin`.