### PR TITLE
Fixed an issue with gallery expiring after an hour

### DIFF
--- a/src/php/admin/class-oauth-helpers.php
+++ b/src/php/admin/class-oauth-helpers.php
@@ -126,6 +126,20 @@ final class OAuth_Helpers {
 			$client->fetchAccessTokenWithAuthCode( GET_Helpers::get_string_variable( 'code' ) );
 			$access_token = $client->getAccessToken();
 
+			if ( ! array_key_exists( 'refresh_token', $access_token ) ) {
+				add_settings_error(
+					'general',
+					'oauth_failed',
+					esc_html__(
+						"The Google authorization API didn't provide a refresh token.",
+						'skaut-google-drive-gallery'
+					),
+					'error'
+				);
+
+				return;
+			}
+
 			$drive_client = new Drive( $client );
 			// phpcs:ignore SlevomatCodingStandard.Functions.RequireSingleLineCall.RequiredSingleLineCall
 			$drive_client->drives->listDrives(

--- a/src/php/class-api-client.php
+++ b/src/php/class-api-client.php
@@ -87,7 +87,7 @@ final class API_Client {
 				)
 			);
 			$raw_client->setAccessType( 'offline' );
-			$raw_client->setApprovalPrompt( 'force' );
+			$raw_client->setPrompt( 'consent' );
 			$raw_client->addScope( Drive::DRIVE_READONLY );
 			self::$raw_client = $raw_client;
 		}


### PR DESCRIPTION
- **Aborting authorization if there is no refresh token**
- **Using Google clients setPrompt instead of setApprovalPrompt**
