### PR TITLE
Format YAML files and unify the dependabot schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,20 +1,21 @@
+---
 version: 2
 updates:
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: daily
-  assignees:
-    - marekdedic
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
-  assignees:
-    - marekdedic
-- package-ecosystem: composer
-  directory: "/"
-  schedule:
-    interval: daily
-  assignees:
-    - marekdedic
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+    assignees:
+      - marekdedic
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+    assignees:
+      - marekdedic
+  - package-ecosystem: composer
+    directory: "/"
+    schedule:
+      interval: daily
+    assignees:
+      - marekdedic

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,19 +3,22 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: "/"
+    open-pull-requests-limit: 9999
     schedule:
-      interval: daily
+      interval: weekly
     assignees:
       - marekdedic
   - package-ecosystem: npm
     directory: "/"
+    open-pull-requests-limit: 9999
     schedule:
-      interval: daily
+      interval: weekly
     assignees:
       - marekdedic
   - package-ecosystem: composer
     directory: "/"
+    open-pull-requests-limit: 9999
     schedule:
-      interval: daily
+      interval: weekly
     assignees:
       - marekdedic

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,5 +1,6 @@
+---
 name: "CI"
-on:
+"on":
   push:
     branches: "*"
   pull_request:
@@ -41,7 +42,9 @@ jobs:
         uses: actions/cache@v6
         with:
           path: "~/.composer/cache"
-          key: composer-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{ hashFiles('composer.json') }}
+          key: >-
+            composer-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{
+            hashFiles('composer.json') }}
           restore-keys: |
             composer-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{ hashFiles('composer.json') }}
             composer-dependencies-${{ runner.os }}-${{ env.cache-version }}-
@@ -54,7 +57,9 @@ jobs:
         uses: actions/cache@v6
         with:
           path: "~/.npm"
-          key: npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{ hashFiles('package.json') }}
+          key: >-
+            npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{
+            hashFiles('package.json') }}
           restore-keys: |
             npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{ hashFiles('package.json') }}
             npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-
@@ -109,7 +114,9 @@ jobs:
         uses: actions/cache@v6
         with:
           path: "~/.composer/cache"
-          key: composer-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{ hashFiles('composer.json') }}
+          key: >-
+            composer-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{
+            hashFiles('composer.json') }}
           restore-keys: |
             composer-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{ hashFiles('composer.json') }}
             composer-dependencies-${{ runner.os }}-${{ env.cache-version }}-
@@ -122,7 +129,9 @@ jobs:
         uses: actions/cache@v6
         with:
           path: "~/.npm"
-          key: npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{ hashFiles('package.json') }}
+          key: >-
+            npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{
+            hashFiles('package.json') }}
           restore-keys: |
             npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{ hashFiles('package.json') }}
             npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-
@@ -147,14 +156,19 @@ jobs:
     needs: build
     strategy:
       matrix:
-        versions: [{php: "5.6", wordpress: "4.9"}, {php: "5.6", wordpress: "5.9"}, {php: "5.6", wordpress: "6.2"}, {php: "7.4", wordpress: "latest"}, {php: "8.3", wordpress: "latest"}]
+        versions:
+          - {php: "5.6", wordpress: "4.9"}
+          - {php: "5.6", wordpress: "5.9"}
+          - {php: "5.6", wordpress: "6.2"}
+          - {php: "7.4", wordpress: "latest"}
+          - {php: "8.3", wordpress: "latest"}
     services:
       mysql:
         image: mysql:5
         ports:
           - 3306:3306
         env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+          MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
     steps:
       - name: "Checkout"
         uses: actions/checkout@v7
@@ -175,7 +189,9 @@ jobs:
         uses: actions/cache@v6
         with:
           path: "~/.composer/cache"
-          key: composer-dependencies-test-${{ runner.os }}-${{ env.cache-version }}-${{ hashFiles('composer.json') }}
+          key: >-
+            composer-dependencies-test-${{ runner.os }}-${{ env.cache-version
+            }}-${{ hashFiles('composer.json') }}
           restore-keys: |
             composer-dependencies-test-${{ runner.os }}-${{ env.cache-version }}-${{ hashFiles('composer.json') }}
             composer-dependencies-test-${{ runner.os }}-${{ env.cache-version }}-
@@ -196,7 +212,9 @@ jobs:
         uses: actions/cache@v6
         with:
           path: "~/.npm"
-          key: npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{ hashFiles('package.json') }}
+          key: >-
+            npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{
+            hashFiles('package.json') }}
           restore-keys: |
             npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{ hashFiles('package.json') }}
             npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-

--- a/.github/workflows/asset-update.yml
+++ b/.github/workflows/asset-update.yml
@@ -1,5 +1,6 @@
+---
 name: "Asset & readme deployment"
-on:
+"on":
   push:
     branches:
       - master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,6 @@
+---
 name: "Release"
-on:
+"on":
   push:
     tags:
       - "*"
@@ -24,7 +25,9 @@ jobs:
         uses: actions/cache@v6
         with:
           path: "~/.composer/cache"
-          key: composer-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{ hashFiles('composer.json') }}
+          key: >-
+            composer-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{
+            hashFiles('composer.json') }}
           restore-keys: |
             composer-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{ hashFiles('composer.json') }}
             composer-dependencies-${{ runner.os }}-${{ env.cache-version }}-
@@ -37,7 +40,9 @@ jobs:
         uses: actions/cache@v6
         with:
           path: "~/.npm"
-          key: npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{ hashFiles('package.json') }}
+          key: >-
+            npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{
+            hashFiles('package.json') }}
           restore-keys: |
             npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-${{ hashFiles('package.json') }}
             npm-dependencies-${{ runner.os }}-${{ env.cache-version }}-
@@ -90,7 +95,10 @@ jobs:
         run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Rename zip artifact
-        run: mv ${{ github.workspace }}/${{ github.event.repository.name }}.zip ${{ github.workspace }}/${{ github.event.repository.name }}.${{ steps.version.outputs.VERSION }}.zip
+        run: >-
+          mv ${{ github.workspace }}/${{ github.event.repository.name }}.zip ${{
+          github.workspace }}/${{ github.event.repository.name }}.${{
+          steps.version.outputs.VERSION }}.zip
 
       - name: "Extract changelog"
         run: |
@@ -103,4 +111,6 @@ jobs:
           name: Version ${{ steps.version.outputs.VERSION }}
           body_path: ./body.md
           fail_on_unmatched_files: true
-          files: ${{ github.workspace }}/${{ github.event.repository.name }}.${{ steps.version.outputs.VERSION }}.zip
+          files: >-
+            ${{ github.workspace }}/${{ github.event.repository.name }}.${{
+            steps.version.outputs.VERSION }}.zip

--- a/.github/workflows/wordpress-version-checker.yml
+++ b/.github/workflows/wordpress-version-checker.yml
@@ -1,5 +1,6 @@
+---
 name: "WordPress version checker"
-on:
+"on":
   push:
     branches:
       - master

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,4 @@
+---
 coverage:
   range: "0...100"
 
@@ -13,11 +14,11 @@ coverage:
 parsers:
   gcov:
     branch_detection:
-      conditional: yes
-      loop: yes
-      method: no
-      macro: no
+      conditional: true
+      loop: true
+      method: false
+      macro: false
 
 comment:
   layout: "reach,diff,flags,files"
-  require_changes: no
+  require_changes: false


### PR DESCRIPTION
Two independent commits; they can be reviewed separately.

## 1. `Format and lint YAML files`

Conform every YAML file in the repository to yamllint's default rules,
which previously reported a large number of issues:

- Add the `---` document start marker.
- Quote the `on:` workflow key so it is not parsed as the boolean true.
- Indent block sequences under their parent key, which was previously
  inconsistent even within a single file.
- Fold over-long values into `>-` block scalars. Every folded value is
  preserved byte for byte.
- Replace `yes`/`no` with `true`/`false` in codecov.yml.

Beyond formatting:

- Quote `MYSQL_ALLOW_EMPTY_PASSWORD: yes`. Unquoted, YAML parsed it as the
  boolean true and the container received "true" rather than the "yes"
  that the MySQL image documents. Both values work, so CI is unaffected.

Verified by comparing every file before and after as parsed YAML: apart
from the changes listed above, no key or value differs. The remaining
long lines are `restore-keys` entries and shell lines inside `run: |`
blocks, which cannot be wrapped without changing their meaning.

## 2. `Unify the dependabot schedule across repositories`

Set every dependabot ecosystem to a weekly schedule with an effectively
unlimited number of open pull requests:

- `interval: weekly`
- `open-pull-requests-limit: 9999` (GitHub's default is 5)

Until now these settings tracked whether the repository had dependabot
auto-merge: the repositories with it used weekly/9999, while those without
used daily and the default limit, so that dependency PRs arrived in small
batches for manual review. Auto-merge is now enabled everywhere, so that
distinction no longer applies.

Ecosystems, directories and assignees are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)