### PR TITLE
Tidied up the tsconfig blocks

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,10 +3,12 @@
     "lib": ["DOM", "ES6", "ScriptHost"],
     "module": "esnext",
     "moduleResolution": "bundler",
-    "types": ["imagesloaded"],
-
     "skipLibCheck": true,
+    // Redundant on TypeScript 6, which enables strict by default, but
+    // @typescript-eslint v7 doesn't know that and disables its type-aware rules
+    // without it. Can be dropped once this repo moves to typescript-eslint v8+.
     "strict": true,
+    "types": ["imagesloaded"],
 
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,


### PR DESCRIPTION
This started out as the same `Removed obsolete strict` clean-up as skaut/crdm-modern@686dab5 and skaut/skautis-integration@e2050842 — but **here `strict` turns out to be load-bearing**, so it stays.

Removing it keeps `tsc` happy (TypeScript 6 enables strict by default), but breaks `lint:ts:eslint` with **69 errors**:

```
error  This rule requires the `strictNullChecks` compiler option to be turned on to function correctly  @typescript-eslint/strict-boolean-expressions
error  ...  @typescript-eslint/prefer-nullish-coalescing
error  ...  @typescript-eslint/no-unnecessary-condition
```

This repo is still on `eslint@^8.57.1` + `@typescript-eslint@^7` with a legacy `.eslintrc.json`, and v7 doesn't know about TypeScript 6's default — it reads `strictNullChecks` as unset and disables the type-aware rules. The repos where the clean-up already landed are all on eslint 9/10 + typescript-eslint v8 with `projectService`, which is why it was safe there.

So this PR just tidies the structure instead:

- moves `skipLibCheck` up into the top block, where it belongs (it is a real setting — `tsc --all` reports `--skipLibCheck default: false`)
- moves `strict` up next to it and comments *why* it is still there, so the next person doing this clean-up doesn't hit the same wall
- removes the stray middle block, leaving the bottom block identical to the other 14 repos'

No behaviour change. Verified `lint:ts:typecheck` and `lint:ts:eslint` both pass, and that `build` output is byte-identical to master's.

Dropping `strict` becomes safe once this repo moves to typescript-eslint v8+.