### PR TITLE
Pin the ES target to ES2017

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "lib": ["DOM", "ES2015", "ScriptHost"],
     "module": "esnext",
     "moduleResolution": "bundler",
     "skipLibCheck": true,
@@ -8,6 +7,7 @@
     // @typescript-eslint v7 doesn't know that and disables its type-aware rules
     // without it. Can be dropped once this repo moves to typescript-eslint v8+.
     "strict": true,
+    "target": "es2017",
     "types": ["imagesloaded"],
 
     "allowUnreachableCode": false,

--- a/vite-builder.config.ts
+++ b/vite-builder.config.ts
@@ -39,6 +39,7 @@ export function viteConfig(
 					},
 				},
 			},
+			target: 'es2017',
 		},
 	});
 }


### PR DESCRIPTION
`tsconfig.json` set **no target**, so TypeScript 6 defaulted to ESNext, and the actual emit came from Vite 8's default `build.target` of `baseline-widely-available` — `chrome111, edge111, firefox114, safari16.4`, roughly ES2022.

Nothing about that level was chosen, and Vite re-cuts its baseline snapshot on every major, so the published floor moved without anyone touching this repo.

## Why ES2017

These bundles are loaded straight into a browser by `wp_enqueue_script` on third-party WordPress sites — no downstream build — so this target is those visitors' floor.

It also matters that it matches **imagelightbox**, which is now ES2017. `gulpfile.js` copies `node_modules/imagelightbox/dist/imagelightbox.umd.cjs` into `dist/bundled/` and enqueues it verbatim, so imagelightbox's floor is already this plugin's floor for anyone using the gallery. Having the two disagree — as they did — meant the effective floor was whichever was lower, decided by accident.

## One line covers all four bundles

`build.target` goes in `vite-builder.config.ts`, which `block`, `shortcode`, `tinymce` and `root_selection` all share. Verified in the built output:

```
dist/admin/js/root_selection.min.js   ?.: downlevelled  ??: downlevelled
dist/admin/js/tinymce.min.js          ?.: downlevelled  ??: downlevelled
dist/frontend/js/block.min.js         ?.: downlevelled  ??: downlevelled
dist/frontend/js/shortcode.min.js     ?.: downlevelled  ??: downlevelled
```

## `lib` is dropped, not bumped

The explicit `"lib": ["DOM", "ES2015", "ScriptHost"]` only existed because there was no target. With `target` unset, TypeScript 6 defaults to ESNext and therefore `lib.es2025.full`, so `lib` was the sole thing stopping this code calling ES2025 APIs — it was doing real work.

Now that `target` is set, it is redundant. `target: "es2017"` resolves the default lib to `lib.es2017.full.d.ts`:

```
/// <reference lib="es2017" />
/// <reference lib="dom" />
/// <reference lib="webworker.importscripts" />
/// <reference lib="scripthost" />
/// <reference lib="dom.iterable" />
```

The old list was a strict *subset* of that — same DOM, ES-level and ScriptHost, additionally omitting `dom.iterable` for no apparent reason. (At an ES2017 floor, iterable `NodeList` is available everywhere anyway: Chrome 51+, Safari 10+.)

Deleting it means `lib` derives from `target`, so the two stay coupled. Raising the target later cannot leave the API guard silently lagging behind the syntax level — which is the same class of drift this change is fixing.

`tsc --noEmit` passes clean without it, and nothing in `src/ts` iterates DOM collections.

## Note on browserslist

`@wordpress/browserslist-config` is left alone and still feeds eslint-plugin-compat and stylelint. It is deliberately *not* used to derive the build target — resolved today it yields Chrome 149 / Firefox 153 / Safari 26.5, which all clear ES2025, so deriving `build.target` from it would ship ES2025 and reach ~86% of users instead of ~95%. It is a `last 2 versions`-style list, not a support floor.

## Verification

- `tsc --noEmit` clean
- `npm run lint:ts:eslint` clean
- `npm run build:js` — all four bundles build, `?.` and `??` confirmed downlevelled in each