### PR TITLE
Point browserslist at the actual support floor and make compat an error

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,7 +26,7 @@
     "camelcase": "error",
     "no-warning-comments": "warn",
     "strict": ["error", "never"],
-    "compat/compat": "warn",
+    "compat/compat": "error",
     "@eslint-community/eslint-comments/no-unused-disable": "error",
     "@eslint-community/eslint-comments/require-description": [
       "error",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "@typescript-eslint/eslint-plugin": "^7.17.0",
         "@typescript-eslint/parser": "^7.18.0",
         "@wordpress/blocks": "=15.16.0",
-        "@wordpress/browserslist-config": "^6.53.0",
         "@wordpress/components": "^39.0.0",
         "@wordpress/editor": "^14.53.0",
         "@wordpress/element": "^8.5.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "@typescript-eslint/eslint-plugin": "^7.17.0",
     "@typescript-eslint/parser": "^7.18.0",
     "@wordpress/blocks": "=15.16.0",
-    "@wordpress/browserslist-config": "^6.53.0",
     "@wordpress/components": "^39.0.0",
     "@wordpress/editor": "^14.53.0",
     "@wordpress/element": "^8.5.0",
@@ -97,6 +96,7 @@
     "vite": "^8.2.2"
   },
   "browserslist": [
-    "extends @wordpress/browserslist-config"
+    "baseline 2019",
+    "not edge 18"
   ]
 }


### PR DESCRIPTION
Two problems compounded here: the browserslist could not flag anything, and even if it could, the rule was only a warning.

## 1. The browserslist was not a floor

`extends @wordpress/browserslist-config` is a rolling **popularity** query. It resolves to **chrome 149 / firefox 153 / safari 26.5** — every one of which clears ES2025 — so nothing this plugin could write would ever be above it.

That is also not what the config is for: its README aims it at Autoprefixer, Babel, ESLint, PostCSS and stylelint as a feature-decision input used *alongside polyfills*, not as a transpile or support floor. Deriving a build target from it would ship ES2025 and reach ~86% of users instead of ~95%.

```json
"browserslist": ["baseline 2019", "not edge 18"]
```

Resolves to **chrome 66 / firefox 65 / safari 13 / edge 79**, matching the ES2017 target set in #3275.

`not edge 18` excludes legacy **EdgeHTML** — Baseline years include it, but it was discontinued in 2019 and force-migrated to Chromium in 2021. (`not dead` does not cover it; browserslist's `dead` list is IE, Opera Mini, BlackBerry and similar.)

## 2. `compat/compat` was only a warning

```diff
-    "compat/compat": "warn",
+    "compat/compat": "error",
```

As a warning it could not fail CI, so even a correct floor would not have stopped a violation from landing. This repo is the only one in the estate where the rule was not an error — every other one already had it at error level via flat config.

## Dependency

`@wordpress/browserslist-config` is dropped; nothing else referenced it. `@wordpress/eslint-plugin` and `@wordpress/stylelint-config` are unaffected.

## Why a Baseline year rather than the alternatives

**Rather than a version list** — one token that states a floor, nothing to hand-maintain per browser.

**Rather than `baseline widely available`** — it rolls upward on a 30-month schedule, so the floor would rise by calendar rather than by decision. That is the wrong default for a plugin running on other people's sites. It also lands on a higher ES level than this package targets and reaches less today.

And mechanically: TypeScript cannot read browserslist, so `lib` is set by hand. If browserslist rolls up while `lib` stays pinned, compat drifts back above the ES level and goes inert — the exact failure this fixes.

## Effect on lint

`lint:ts` stays **clean with the rule promoted to error**, so nothing in `src` violates the new floor — the ES2017 work in #3275 already brought it into line.

Stylelint reports three warnings: partially supported `css-logical-props` and `css-overflow` at Safari 13 / Chrome 66, and `css-zoom` in older Firefox. Those are **new signal, not regressions** — the CSS had never been checked against a floor that meant anything. They are `severity: "warning"`, so they do not gate CI.
