### PR TITLE
Make the CSS compatibility rule an error

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "build:js:tinymce": "FORCE_COLOR=1 vite build --config tinymce.vite.config.ts",
     "build:js": "run-p -c --aggregate-output build:js:*",
     "build": "run-p -c --aggregate-output build:*",
-    "lint:css:stylelint": "stylelint --color 'src/**/*.css'",
+    "lint:css:stylelint": "stylelint --color --report-needless-disables 'src/**/*.css'",
     "lint:css": "run-p -c --aggregate-output lint:css:*",
     "lint:php:phan": "export PHAN_DISABLE_XDEBUG_WARN=1; vendor/bin/phan",
     "lint:php:phpcs": "vendor/bin/phpcs",

--- a/src/css/admin/tinymce.css
+++ b/src/css/admin/tinymce.css
@@ -16,7 +16,10 @@
 }
 
 #sgdg-tinymce-overflow {
-	inset: 60px 0;
+	bottom: 60px;
+	left: 0;
+	right: 0;
+	top: 60px;
 	overflow-y: auto;
 	padding: 0 15px;
 	position: absolute;

--- a/src/css/frontend/block.css
+++ b/src/css/frontend/block.css
@@ -16,11 +16,8 @@
 }
 
 .sgdg-block-settings-row .components-toggle-control {
-	display: -moz-inline-box;
-	display: inline-block; /* stylelint-disable-line plugin/no-unsupported-browser-features */
-	*display: inline;
+	display: inline-block;
 	margin: 0 0 -6px -52px !important;
-	*zoom: 1;
 }
 
 .sgdg-block-settings-boolean {

--- a/src/css/frontend/shortcode.css
+++ b/src/css/frontend/shortcode.css
@@ -7,23 +7,23 @@
 }
 
 .sgdg-grid-a {
-	box-shadow: none !important; /* stylelint-disable-line plugin/no-unsupported-browser-features */
+	box-shadow: none !important;
 }
 
 .sgdg-grid-square {
 	background-position: center;
-	background-size: cover; /* stylelint-disable-line plugin/no-unsupported-browser-features */
+	background-size: cover;
 }
 
 .sgdg-grid-img {
-	box-shadow: none !important; /* stylelint-disable-line plugin/no-unsupported-browser-features */
+	box-shadow: none !important;
 	display: block;
 	height: 100% !important;
 }
 
 .sgdg-dir-overlay {
 	background-color: #7f7f7f;
-	background-color: rgb(0, 0, 0, 50%); /* stylelint-disable-line plugin/no-unsupported-browser-features */
+	background-color: rgb(0, 0, 0, 50%);
 	bottom: 0;
 	color: #fff;
 	left: 0;
@@ -51,22 +51,22 @@
 
 .sgdg-loading,
 .sgdg-loading div {
-	border-radius: 50%; /* stylelint-disable-line plugin/no-unsupported-browser-features */
+	border-radius: 50%;
 }
 
 .sgdg-loading {
 	background-color: #9b9b9b;
-	background-color: rgb(130, 130, 130, 80%); /* stylelint-disable-line plugin/no-unsupported-browser-features */
-	box-shadow: 0 0 2.5em #b3b3b3; /* 40 */ /* stylelint-disable-line plugin/no-unsupported-browser-features */
-	box-shadow: 0 0 2.5em rgb(130, 130, 130, 60%); /* stylelint-disable-line plugin/no-unsupported-browser-features */
-	box-sizing: content-box; /* stylelint-disable-line plugin/no-unsupported-browser-features */
+	background-color: rgb(130, 130, 130, 80%);
+	box-shadow: 0 0 2.5em #b3b3b3; /* 40 */
+	box-shadow: 0 0 2.5em rgb(130, 130, 130, 60%);
+	box-sizing: content-box;
 	margin: 10px auto;
 	padding: 0.65em;
 	width: 1.3em;
 }
 
 .sgdg-loading div {
-	animation: sgdg-loading 0.5s ease infinite; /* stylelint-disable-line plugin/no-unsupported-browser-features */
+	animation: sgdg-loading 0.5s ease infinite;
 	background-color: #fff;
 	height: 1.3em;
 }
@@ -74,18 +74,18 @@
 @keyframes sgdg-loading {
 
 	0% {
-		opacity: 0.5; /* stylelint-disable-line plugin/no-unsupported-browser-features */
-		transform: scale(0.75); /* stylelint-disable-line plugin/no-unsupported-browser-features */
+		opacity: 0.5;
+		transform: scale(0.75);
 	}
 
 	50% {
-		opacity: 1; /* stylelint-disable-line plugin/no-unsupported-browser-features */
-		transform: scale(1); /* stylelint-disable-line plugin/no-unsupported-browser-features */
+		opacity: 1;
+		transform: scale(1);
 	}
 
 	100% {
-		opacity: 0.5; /* stylelint-disable-line plugin/no-unsupported-browser-features */
-		transform: scale(0.75); /* stylelint-disable-line plugin/no-unsupported-browser-features */
+		opacity: 0.5;
+		transform: scale(0.75);
 	}
 }
 
@@ -96,8 +96,8 @@
 
 .sgdg-more-button div {
 	background-color: #7f7f7f;
-	background-color: rgb(0, 0, 0, 50%); /* stylelint-disable-line plugin/no-unsupported-browser-features */
-	border-radius: 2px; /* stylelint-disable-line plugin/no-unsupported-browser-features */
+	background-color: rgb(0, 0, 0, 50%);
+	border-radius: 2px;
 	color: #fff;
 	cursor: pointer;
 	display: inline;

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -7,11 +7,20 @@ export default {
 	plugins: ['stylelint-no-unsupported-browser-features'],
 	rules: {
 		'color-function-notation': 'legacy',
+		// The `inset` shorthand needs Chrome 87 / Safari 14.1, above our floor, so
+		// the longhands are deliberate.
+		'declaration-block-no-redundant-longhand-properties': [
+			true,
+			{
+				ignoreShorthands: ['inset'],
+			},
+		],
 		'plugin/no-unsupported-browser-features': [
 			true,
 			{
-				severity: 'warning',
-				ignore: 'css-sel2',
+				// Caniuse flags css-overflow as partial over `overflow: clip` and
+				// two-value syntax. Plain `overflow-y: auto` is universal.
+				ignore: ['css-sel2', 'css-overflow'],
 			},
 		],
 	},


### PR DESCRIPTION
`plugin/no-unsupported-browser-features` was `severity: "warning"`, so it could never fail CI. Now that #3277 gives it a real floor — `baseline 2019`, chrome 66 / firefox 65 / safari 13 — the rule can gate.

Promoting it required resolving all three findings rather than suppressing them wholesale.

## 1. `css-zoom` — dead IE7 hacks, deleted

```diff
-	display: -moz-inline-box;
-	display: inline-block; /* stylelint-disable-line plugin/no-unsupported-browser-features */
-	*display: inline;
+	display: inline-block;
 	margin: 0 0 -6px -52px !important;
-	*zoom: 1;
```

The `*property` star hack targets **IE7 and below**; `-moz-inline-box` was a pre-2011 Gecko value. Neither does anything in any browser we support.

Deleting them also removes the `stylelint-disable-line` that existed only to hide the legacy `display` value — so the fix retires a suppression rather than adding one.

## 2. `inset` — genuine violation, fixed

```diff
-	inset: 60px 0;
+	bottom: 60px;
+	left: 0;
+	right: 0;
+	top: 60px;
```

The shorthand needs **Chrome 87 / Firefox 66 / Safari 14.1**, above the floor.

This then made `declaration-block-no-redundant-longhand-properties` demand the shorthand back — the two rules contradict each other. `ignoreShorthands: ['inset']` settles it in favour of the compat floor, since the shorthand is precisely what our supported browsers lack.

## 3. `css-overflow` — false positive, ignored by name

Caniuse marks the feature partially supported because of `overflow: clip` and the two-value syntax. The only declaration here is `overflow-y: auto`, universal for over a decade — the rule flags the *property*, not the value, so there is nothing to fix.

`css-sel2` was already ignored and is unchanged.

## 4. 18 dead suppressions removed

`shortcode.css` carried 18 `stylelint-disable-line plugin/no-unsupported-browser-features` comments, on declarations like:

```
box-shadow: none !important;
background-size: cover;
border-radius: 50%;
box-sizing: content-box;
opacity: 0.5;
transform: scale(0.75);
animation: sgdg-loading 0.5s ease infinite;
```

All universally supported since roughly 2012. Every one suppressed **nothing** — verified with `--report-needless-disables`, which flags all 18. They are fossils of some much older browserslist, and because none carried a comment there was no way to tell they had expired.

## 5. `--report-needless-disables` added to the lint script

```diff
-"lint:css:stylelint": "stylelint --color 'src/**/*.css'"
+"lint:css:stylelint": "stylelint --color --report-needless-disables 'src/**/*.css'"
```

This is what found all 18. Without it a suppression outlives its cause silently — which is exactly how 18 accumulated here.

## Verification

- `stylelint` clean including `--report-needless-disables`
- `npm run lint:ts` 0 errors
- `npm run build` succeeds — all four bundles