### PR TITLE
Check browser support against the built CSS, not the source

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,176 +1,212 @@
 {
-  "parserOptions": {
-    "project": "./tsconfig.json",
-    "sourceType": "script"
-  },
-  "env": {
-    "browser": true,
-    "node": false
-  },
-  "plugins": [
-    "compat",
-    "prefer-arrow-functions",
-    "simple-import-sort",
-    "@typescript-eslint"
-  ],
-  "extends": [
-    "eslint:recommended",
-    "plugin:react/recommended",
-    "plugin:@eslint-community/eslint-comments/recommended",
-    "plugin:@wordpress/eslint-plugin/recommended",
-    "plugin:@typescript-eslint/strict-type-checked",
-    "plugin:@typescript-eslint/stylistic-type-checked"
-  ],
-  "rules": {
-    "arrow-body-style": ["error", "as-needed"],
-    "camelcase": "error",
-    "no-warning-comments": "warn",
-    "strict": ["error", "never"],
-    "compat/compat": "error",
-    "@eslint-community/eslint-comments/no-unused-disable": "error",
-    "@eslint-community/eslint-comments/require-description": [
-      "error",
-      {
-        "ignore": ["eslint-env"]
-      }
-    ],
-    "prefer-arrow-functions/prefer-arrow-functions": [
-      "error",
-      {
-        "allowNamedFunctions": true
-      }
-    ],
-    "simple-import-sort/imports": "error",
-    "simple-import-sort/exports": "error",
-    "@typescript-eslint/array-type": ["error", { "default": "generic" }],
-    "@typescript-eslint/class-methods-use-this": [
-      "error",
-      {
-        "ignoreOverrideMethods": true
-      }
-    ],
-    "@typescript-eslint/consistent-type-exports": "error",
-    "@typescript-eslint/consistent-type-imports": "error",
-    "@typescript-eslint/default-param-last": "error",
-    "@typescript-eslint/explicit-function-return-type": "error",
-    "@typescript-eslint/explicit-member-accessibility": "error",
-    "@typescript-eslint/explicit-module-boundary-types": "error",
-    "@typescript-eslint/init-declarations": "error",
-    "@typescript-eslint/member-ordering": "error",
-    "@typescript-eslint/method-signature-style": ["error", "method"],
-    "@typescript-eslint/no-base-to-string": "error",
-    "@typescript-eslint/no-import-type-side-effects": "error",
-    "@typescript-eslint/no-loop-func": "error",
-    "@typescript-eslint/no-require-imports": "error",
-    "@typescript-eslint/no-shadow": "error",
-    "@typescript-eslint/no-unnecessary-qualifier": "error",
-    "@typescript-eslint/no-unsafe-unary-minus": "error",
-    "@typescript-eslint/no-unused-expressions": "error",
-    "@typescript-eslint/no-unused-vars": "error",
-    "@typescript-eslint/no-use-before-define": "error",
-    "@typescript-eslint/no-useless-empty-export": "error",
-    "@typescript-eslint/parameter-properties": "error",
-    "@typescript-eslint/prefer-enum-initializers": "error",
-    "@typescript-eslint/prefer-find": "error",
-    "@typescript-eslint/prefer-readonly": "error",
-    "@typescript-eslint/prefer-regexp-exec": "error",
-    "@typescript-eslint/promise-function-async": "error",
-    "@typescript-eslint/require-array-sort-compare": "error",
-    "@typescript-eslint/return-await": "error",
-    "@typescript-eslint/sort-type-constituents": "error",
-    "@typescript-eslint/strict-boolean-expressions": "error",
-    "@typescript-eslint/switch-exhaustiveness-check": "error",
-    "@typescript-eslint/typedef": "error",
-    "react/button-has-type": "error",
-    "react/default-props-match-prop-types": "error",
-    "react/destructuring-assignment": "error",
-    "react/no-array-index-key": "error",
-    "react/no-danger": "error",
-    "react/no-invalid-html-attribute": "error",
-    "react/no-namespace": "error",
-    "react/no-object-type-as-default-prop": "error",
-    "react/no-this-in-sfc": "error",
-    "react/no-typos": "error",
-    "react/no-unknown-property": "error",
-    "react/no-unstable-nested-components": "error",
-    "react/prefer-es6-class": "error",
-    "react/prefer-stateless-function": "error",
-    "react/prefer-read-only-props": "error",
-    "react/require-default-props": ["error", { "classes": "defaultProps" }],
-    "react/sort-default-props": "error",
-    "react/sort-prop-types": "error",
-    "react/state-in-constructor": "error",
-    "react/style-prop-object": "error",
-    "react/void-dom-elements-no-children": "error"
-  },
-  "overrides": [
-    {
-      "parserOptions": {
-        "project": null
-      },
-      "files": ["gulpfile.js", "webpack.config.js"],
-      "rules": {
-        "deprecation/deprecation": "off",
-        "@typescript-eslint/await-thenable": "off",
-        "@typescript-eslint/consistent-type-exports": "off",
-        "@typescript-eslint/dot-notation": "off",
-        "@typescript-eslint/explicit-function-return-type": "off",
-        "@typescript-eslint/no-array-delete": "off",
-        "@typescript-eslint/no-base-to-string": "off",
-        "@typescript-eslint/no-confusing-void-expression": "off",
-        "@typescript-eslint/no-duplicate-type-constituents": "off",
-        "@typescript-eslint/no-floating-promises": "off",
-        "@typescript-eslint/no-implied-eval": "off",
-        "@typescript-eslint/no-meaningless-void-operator": "off",
-        "@typescript-eslint/no-misused-promises": "off",
-        "@typescript-eslint/no-mixed-enums": "off",
-        "@typescript-eslint/no-redundant-type-constituents": "off",
-        "@typescript-eslint/no-require-imports": "off",
-        "@typescript-eslint/no-unnecessary-boolean-literal-compare": "off",
-        "@typescript-eslint/no-unnecessary-condition": "off",
-        "@typescript-eslint/no-unnecessary-qualifier": "off",
-        "@typescript-eslint/no-unnecessary-template-expression": "off",
-        "@typescript-eslint/no-unnecessary-type-arguments": "off",
-        "@typescript-eslint/no-unnecessary-type-assertion": "off",
-        "@typescript-eslint/no-unsafe-argument": "off",
-        "@typescript-eslint/no-unsafe-assignment": "off",
-        "@typescript-eslint/no-unsafe-call": "off",
-        "@typescript-eslint/no-unsafe-enum-comparison": "off",
-        "@typescript-eslint/no-unsafe-member-access": "off",
-        "@typescript-eslint/no-unsafe-return": "off",
-        "@typescript-eslint/no-var-requires": "off",
-        "@typescript-eslint/non-nullable-type-assertion-style": "off",
-        "@typescript-eslint/only-throw-error": "off",
-        "@typescript-eslint/prefer-find": "off",
-        "@typescript-eslint/prefer-includes": "off",
-        "@typescript-eslint/prefer-nullish-coalescing": "off",
-        "@typescript-eslint/prefer-optional-chain": "off",
-        "@typescript-eslint/prefer-promise-reject-errors": "off",
-        "@typescript-eslint/prefer-readonly": "off",
-        "@typescript-eslint/prefer-reduce-type-parameter": "off",
-        "@typescript-eslint/prefer-regexp-exec": "off",
-        "@typescript-eslint/prefer-return-this-type": "off",
-        "@typescript-eslint/prefer-string-starts-ends-with": "off",
-        "@typescript-eslint/promise-function-async": "off",
-        "@typescript-eslint/require-array-sort-compare": "off",
-        "@typescript-eslint/require-await": "off",
-        "@typescript-eslint/restrict-plus-operands": "off",
-        "@typescript-eslint/restrict-template-expressions": "off",
-        "@typescript-eslint/return-await": "off",
-        "@typescript-eslint/strict-boolean-expressions": "off",
-        "@typescript-eslint/switch-exhaustiveness-check": "off",
-        "@typescript-eslint/unbound-method": "off",
-        "@typescript-eslint/use-unknown-in-catch-callback-variable": "off"
-      }
-    }
-  ],
-  "globals": {
-    "tb_remove": "readonly",
-    "tb_show": "readonly"
-  },
-  "settings": {
-    "import/resolver": {
-      "typescript": true
-    }
-  }
+	"parserOptions": {
+		"project": "./tsconfig.json",
+		"sourceType": "script"
+	},
+	"env": {
+		"browser": true,
+		"node": false
+	},
+	"plugins": [
+		"compat",
+		"prefer-arrow-functions",
+		"simple-import-sort",
+		"@typescript-eslint"
+	],
+	"extends": [
+		"eslint:recommended",
+		"plugin:react/recommended",
+		"plugin:@eslint-community/eslint-comments/recommended",
+		"plugin:@wordpress/eslint-plugin/recommended",
+		"plugin:@typescript-eslint/strict-type-checked",
+		"plugin:@typescript-eslint/stylistic-type-checked"
+	],
+	"rules": {
+		"arrow-body-style": [
+			"error",
+			"as-needed"
+		],
+		"camelcase": "error",
+		"no-warning-comments": "warn",
+		"strict": [
+			"error",
+			"never"
+		],
+		"compat/compat": "error",
+		"@eslint-community/eslint-comments/no-unused-disable": "error",
+		"@eslint-community/eslint-comments/require-description": [
+			"error",
+			{
+				"ignore": [
+					"eslint-env"
+				]
+			}
+		],
+		"prefer-arrow-functions/prefer-arrow-functions": [
+			"error",
+			{
+				"allowNamedFunctions": true
+			}
+		],
+		"simple-import-sort/imports": "error",
+		"simple-import-sort/exports": "error",
+		"@typescript-eslint/array-type": [
+			"error",
+			{
+				"default": "generic"
+			}
+		],
+		"@typescript-eslint/class-methods-use-this": [
+			"error",
+			{
+				"ignoreOverrideMethods": true
+			}
+		],
+		"@typescript-eslint/consistent-type-exports": "error",
+		"@typescript-eslint/consistent-type-imports": "error",
+		"@typescript-eslint/default-param-last": "error",
+		"@typescript-eslint/explicit-function-return-type": "error",
+		"@typescript-eslint/explicit-member-accessibility": "error",
+		"@typescript-eslint/explicit-module-boundary-types": "error",
+		"@typescript-eslint/init-declarations": "error",
+		"@typescript-eslint/member-ordering": "error",
+		"@typescript-eslint/method-signature-style": [
+			"error",
+			"method"
+		],
+		"@typescript-eslint/no-base-to-string": "error",
+		"@typescript-eslint/no-import-type-side-effects": "error",
+		"@typescript-eslint/no-loop-func": "error",
+		"@typescript-eslint/no-require-imports": "error",
+		"@typescript-eslint/no-shadow": "error",
+		"@typescript-eslint/no-unnecessary-qualifier": "error",
+		"@typescript-eslint/no-unsafe-unary-minus": "error",
+		"@typescript-eslint/no-unused-expressions": "error",
+		"@typescript-eslint/no-unused-vars": "error",
+		"@typescript-eslint/no-use-before-define": "error",
+		"@typescript-eslint/no-useless-empty-export": "error",
+		"@typescript-eslint/parameter-properties": "error",
+		"@typescript-eslint/prefer-enum-initializers": "error",
+		"@typescript-eslint/prefer-find": "error",
+		"@typescript-eslint/prefer-readonly": "error",
+		"@typescript-eslint/prefer-regexp-exec": "error",
+		"@typescript-eslint/promise-function-async": "error",
+		"@typescript-eslint/require-array-sort-compare": "error",
+		"@typescript-eslint/return-await": "error",
+		"@typescript-eslint/sort-type-constituents": "error",
+		"@typescript-eslint/strict-boolean-expressions": "error",
+		"@typescript-eslint/switch-exhaustiveness-check": "error",
+		"@typescript-eslint/typedef": "error",
+		"react/button-has-type": "error",
+		"react/default-props-match-prop-types": "error",
+		"react/destructuring-assignment": "error",
+		"react/no-array-index-key": "error",
+		"react/no-danger": "error",
+		"react/no-invalid-html-attribute": "error",
+		"react/no-namespace": "error",
+		"react/no-object-type-as-default-prop": "error",
+		"react/no-this-in-sfc": "error",
+		"react/no-typos": "error",
+		"react/no-unknown-property": "error",
+		"react/no-unstable-nested-components": "error",
+		"react/prefer-es6-class": "error",
+		"react/prefer-stateless-function": "error",
+		"react/prefer-read-only-props": "error",
+		"react/require-default-props": [
+			"error",
+			{
+				"classes": "defaultProps"
+			}
+		],
+		"react/sort-default-props": "error",
+		"react/sort-prop-types": "error",
+		"react/state-in-constructor": "error",
+		"react/style-prop-object": "error",
+		"react/void-dom-elements-no-children": "error"
+	},
+	"overrides": [
+		{
+			"parserOptions": {
+				"project": null
+			},
+			"files": [
+				"gulpfile.js",
+				"webpack.config.js",
+				"scripts/check-css-compat.js"
+			],
+			"rules": {
+				"deprecation/deprecation": "off",
+				"@typescript-eslint/await-thenable": "off",
+				"@typescript-eslint/consistent-type-exports": "off",
+				"@typescript-eslint/dot-notation": "off",
+				"@typescript-eslint/explicit-function-return-type": "off",
+				"@typescript-eslint/no-array-delete": "off",
+				"@typescript-eslint/no-base-to-string": "off",
+				"@typescript-eslint/no-confusing-void-expression": "off",
+				"@typescript-eslint/no-duplicate-type-constituents": "off",
+				"@typescript-eslint/no-floating-promises": "off",
+				"@typescript-eslint/no-implied-eval": "off",
+				"@typescript-eslint/no-meaningless-void-operator": "off",
+				"@typescript-eslint/no-misused-promises": "off",
+				"@typescript-eslint/no-mixed-enums": "off",
+				"@typescript-eslint/no-redundant-type-constituents": "off",
+				"@typescript-eslint/no-require-imports": "off",
+				"@typescript-eslint/no-unnecessary-boolean-literal-compare": "off",
+				"@typescript-eslint/no-unnecessary-condition": "off",
+				"@typescript-eslint/no-unnecessary-qualifier": "off",
+				"@typescript-eslint/no-unnecessary-template-expression": "off",
+				"@typescript-eslint/no-unnecessary-type-arguments": "off",
+				"@typescript-eslint/no-unnecessary-type-assertion": "off",
+				"@typescript-eslint/no-unsafe-argument": "off",
+				"@typescript-eslint/no-unsafe-assignment": "off",
+				"@typescript-eslint/no-unsafe-call": "off",
+				"@typescript-eslint/no-unsafe-enum-comparison": "off",
+				"@typescript-eslint/no-unsafe-member-access": "off",
+				"@typescript-eslint/no-unsafe-return": "off",
+				"@typescript-eslint/no-var-requires": "off",
+				"@typescript-eslint/non-nullable-type-assertion-style": "off",
+				"@typescript-eslint/only-throw-error": "off",
+				"@typescript-eslint/prefer-find": "off",
+				"@typescript-eslint/prefer-includes": "off",
+				"@typescript-eslint/prefer-nullish-coalescing": "off",
+				"@typescript-eslint/prefer-optional-chain": "off",
+				"@typescript-eslint/prefer-promise-reject-errors": "off",
+				"@typescript-eslint/prefer-readonly": "off",
+				"@typescript-eslint/prefer-reduce-type-parameter": "off",
+				"@typescript-eslint/prefer-regexp-exec": "off",
+				"@typescript-eslint/prefer-return-this-type": "off",
+				"@typescript-eslint/prefer-string-starts-ends-with": "off",
+				"@typescript-eslint/promise-function-async": "off",
+				"@typescript-eslint/require-array-sort-compare": "off",
+				"@typescript-eslint/require-await": "off",
+				"@typescript-eslint/restrict-plus-operands": "off",
+				"@typescript-eslint/restrict-template-expressions": "off",
+				"@typescript-eslint/return-await": "off",
+				"@typescript-eslint/strict-boolean-expressions": "off",
+				"@typescript-eslint/switch-exhaustiveness-check": "off",
+				"@typescript-eslint/unbound-method": "off",
+				"@typescript-eslint/use-unknown-in-catch-callback-variable": "off"
+			}
+		},
+		{
+			"files": [
+				"scripts/**/*.js"
+			],
+			"env": {
+				"node": true
+			},
+			"rules": {
+				"no-console": "off"
+			}
+		}
+	],
+	"globals": {
+		"tb_remove": "readonly",
+		"tb_show": "readonly"
+	},
+	"settings": {
+		"import/resolver": {
+			"typescript": true
+		}
+	}
 }

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -72,6 +72,10 @@ jobs:
         run: |
           npm run build
 
+      - name: "Check the built output"
+        run: |
+          npm run check
+
       - name: "Upload artifact"
         uses: actions/upload-artifact@v7
         with:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,16 +2,35 @@
 
 import { Transform } from 'node:stream';
 
+import browserslist from 'browserslist';
 import gulp from 'gulp';
-import cleanCSS from 'gulp-clean-css';
 import rename from 'gulp-rename';
 import replace from 'gulp-replace';
 import shell from 'gulp-shell';
+import { browserslistToTargets, transform } from 'lightningcss';
+
+const cssTargets = browserslistToTargets(browserslist());
+
+// Minifies, and lowers modern syntax and adds prefixes for the browserslist floor.
+const lightningCSS = () =>
+	new Transform({
+		objectMode: true,
+		transform: (file, _encoding, callback) => {
+			const { code } = transform({
+				code: file.contents,
+				filename: file.path,
+				minify: true,
+				targets: cssTargets,
+			});
+			file.contents = Buffer.from(code);
+			callback(null, file);
+		},
+	});
 
 gulp.task('build:css:admin', () =>
 	gulp
 		.src(['src/css/admin/*.css'])
-		.pipe(cleanCSS())
+		.pipe(lightningCSS())
 		.pipe(rename({ suffix: '.min' }))
 		.pipe(gulp.dest('dist/admin/css/'))
 );
@@ -19,7 +38,7 @@ gulp.task('build:css:admin', () =>
 gulp.task('build:css:frontend', () =>
 	gulp
 		.src(['src/css/frontend/*.css'])
-		.pipe(cleanCSS())
+		.pipe(lightningCSS())
 		.pipe(rename({ suffix: '.min' }))
 		.pipe(gulp.dest('dist/frontend/css/'))
 );
@@ -100,6 +119,7 @@ gulp.task(
 		() =>
 			gulp
 				.src(['node_modules/imagelightbox/dist/imagelightbox.css'])
+				.pipe(lightningCSS())
 				.pipe(gulp.dest('dist/bundled/')),
 		() =>
 			gulp

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,8 @@
         "@wordpress/env": "^11.13.0",
         "@wordpress/eslint-plugin": "^24.5.0",
         "@wordpress/stylelint-config": "^24.2.0",
+        "browserslist": "^4.28.8",
+        "doiuse": "^6.0.6",
         "eslint": "^8.57.1",
         "eslint-import-resolver-typescript": "^4.4.5",
         "eslint-plugin-compat": "^6.2.1",
@@ -37,17 +39,17 @@
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-simple-import-sort": "^14.0.0",
         "gulp": "^5.0.1",
-        "gulp-clean-css": "^4.3.0",
         "gulp-rename": "^2.1.0",
         "gulp-replace": "^1.1.4",
         "gulp-shell": "^0.8.0",
         "jquery": "^4.0.0",
+        "lightningcss": "^1.33.0",
         "npm-run-all": "^4.1.5",
+        "postcss": "^8.5.26",
         "prettier": "^3.9.6",
         "rimraf": "^6.1.3",
         "stylelint": "^16.26.1",
         "stylelint-config-standard": "^39.0.1",
-        "stylelint-no-unsupported-browser-features": "^8.1.1",
         "tinymce": "^8.8.2",
         "typescript": "^6.0.3",
         "vite": "^8.2.2"
@@ -13338,29 +13340,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/clean-css": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",
-      "integrity": "sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "source-map": "~0.6.0"
-      },
-      "engines": {
-        "node": ">= 4.0"
-      }
-    },
-    "node_modules/clean-css/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/clean-git-ref": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/clean-git-ref/-/clean-git-ref-2.0.1.tgz",
@@ -16981,19 +16960,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/gulp-clean-css": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/gulp-clean-css/-/gulp-clean-css-4.3.0.tgz",
-      "integrity": "sha512-mGyeT3qqFXTy61j0zOIciS4MkYziF2U594t2Vs9rUnpkEHqfu6aDITMp8xOvZcvdX61Uz3y1mVERRYmjzQF5fg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "clean-css": "4.2.3",
-        "plugin-error": "1.0.1",
-        "through2": "3.0.1",
-        "vinyl-sourcemaps-apply": "0.2.1"
       }
     },
     "node_modules/gulp-cli": {
@@ -23085,24 +23051,6 @@
         "stylelint": "^16.23.0"
       }
     },
-    "node_modules/stylelint-no-unsupported-browser-features": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/stylelint-no-unsupported-browser-features/-/stylelint-no-unsupported-browser-features-8.1.1.tgz",
-      "integrity": "sha512-sLEe6NUFoWL2vGt6IKKllQEKfKgVxmvTBFs1JVMHKKLWzxtWAXaqSxJvH+j0URM4vLQQqzC/wXc9Kp3XBNKdBw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.26.3",
-        "doiuse": "^6.0.6",
-        "postcss": "^8.4.32"
-      },
-      "engines": {
-        "node": ">=18.12.0"
-      },
-      "peerDependencies": {
-        "stylelint": ">=16.0.2"
-      }
-    },
     "node_modules/stylelint-scss": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-6.14.0.tgz",
@@ -24375,16 +24323,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/vinyl-sourcemaps-apply": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
-      "integrity": "sha512-+oDh3KYZBoZC8hfocrbrxbLUeaYtQK7J5WU5Br9VqWqmCll3tFJqKp97GC9GmMsVIL0qnx2DgEDVxdo5EZ5sSw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "source-map": "^0.5.1"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "lint:php:phpmd": "vendor/bin/phpmd src,tests,.phan/config.php,scoper.inc.php text phpmd.xml",
     "lint:php:phpstan": "vendor/bin/phpstan",
     "lint:php": "run-p -c --aggregate-output lint:php:*",
-    "lint:ts:eslint": "eslint --color 'src/**/*.ts' 'gulpfile.js' '*.config.{js,ts}'",
+    "lint:ts:eslint": "eslint --color 'src/**/*.ts' 'gulpfile.js' 'scripts/**/*.js' '*.config.{js,ts}'",
     "lint:ts:typecheck": "tsc --noEmit",
     "lint:ts": "run-p -c --aggregate-output lint:ts:*",
     "lint": "run-p -c --aggregate-output lint:*",
@@ -46,7 +46,9 @@
     "posttest:php:phpunit": "composer install",
     "test:php": "run-p -c --aggregate-output test:php:*",
     "test": "run-p -c --aggregate-output test:*",
-    "plugin-check": "wp-env start && wp-env run cli wp plugin check skaut-google-drive-gallery --ignore-codes=missing_composer_json_file; CODE=$?; wp-env stop; exit $CODE"
+    "plugin-check": "wp-env start && wp-env run cli wp plugin check skaut-google-drive-gallery --ignore-codes=missing_composer_json_file; CODE=$?; wp-env stop; exit $CODE",
+    "check": "run-p -c --aggregate-output check:*",
+    "check:css-compat": "node scripts/check-css-compat.js"
   },
   "engines": {
     "npm": "^8.0.0"
@@ -72,6 +74,8 @@
     "@wordpress/env": "^11.13.0",
     "@wordpress/eslint-plugin": "^24.5.0",
     "@wordpress/stylelint-config": "^24.2.0",
+    "browserslist": "^4.28.8",
+    "doiuse": "^6.0.6",
     "eslint": "^8.57.1",
     "eslint-import-resolver-typescript": "^4.4.5",
     "eslint-plugin-compat": "^6.2.1",
@@ -80,17 +84,17 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-simple-import-sort": "^14.0.0",
     "gulp": "^5.0.1",
-    "gulp-clean-css": "^4.3.0",
     "gulp-rename": "^2.1.0",
     "gulp-replace": "^1.1.4",
     "gulp-shell": "^0.8.0",
     "jquery": "^4.0.0",
+    "lightningcss": "^1.33.0",
     "npm-run-all": "^4.1.5",
+    "postcss": "^8.5.26",
     "prettier": "^3.9.6",
     "rimraf": "^6.1.3",
     "stylelint": "^16.26.1",
     "stylelint-config-standard": "^39.0.1",
-    "stylelint-no-unsupported-browser-features": "^8.1.1",
     "tinymce": "^8.8.2",
     "typescript": "^6.0.3",
     "vite": "^8.2.2"

--- a/scripts/check-css-compat.js
+++ b/scripts/check-css-compat.js
@@ -1,0 +1,85 @@
+import { readdir, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import doiuse from 'doiuse';
+import postcss from 'postcss';
+
+const DIST = 'dist';
+
+/*
+ * Declarations that trip a partial-support flag while falling outside what the
+ * flag actually covers. Each predicate matches only the safe subset, so a value
+ * the flag does cover is still reported.
+ */
+const SAFE = {
+	/*
+	 * Notes 1 and 2 are the two-value `overflow` shorthand and the `clip`
+	 * value. Only single-value overflow declarations ship.
+	 */
+	'css-overflow': ({ value }) =>
+		!/\bclip\b/u.test(value) && value.trim().split(/\s+/u).length === 1,
+};
+
+/**
+ * @param {string} dir
+ * @return {Promise<Array<string>>} every .css file below dir, recursively
+ */
+const cssFiles = async (dir) => {
+	const entries = await readdir(dir, { withFileTypes: true });
+	const nested = await Promise.all(
+		entries.map(async (entry) => {
+			const path = join(dir, entry.name);
+			if (entry.isDirectory()) {
+				return cssFiles(path);
+			}
+			return entry.name.endsWith('.css') ? [path] : [];
+		})
+	);
+	return nested.flat();
+};
+
+// Fail closed: an empty file list makes doiuse report nothing, which reads as a pass.
+const files = await cssFiles(DIST).catch(() => []);
+if (files.length === 0) {
+	console.error(`No CSS found under ${DIST}/ - run \`npm run build\` first.`);
+	process.exit(1);
+}
+
+const problems = (
+	await Promise.all(
+		files.map(async (file) => {
+			const found = [];
+			const css = await readFile(file, 'utf8');
+			await postcss([
+				doiuse({
+					onFeatureUsage: ({ feature, featureData, usage }) => {
+						if (
+							Object.hasOwn(SAFE, feature) &&
+							usage.type === 'decl' &&
+							SAFE[feature](usage)
+						) {
+							return;
+						}
+						const what =
+							usage.type === 'decl'
+								? `${usage.prop}: ${usage.value}`
+								: `@${usage.name} ${usage.params}`;
+						const { column, line } = usage.source.start;
+						found.push(
+							`${file}:${line}:${column}  ${what}  (${feature}: ${featureData.missing || featureData.partial})`
+						);
+					},
+				}),
+			]).process(css, { from: file });
+			return found;
+		})
+	)
+).flat();
+
+if (problems.length > 0) {
+	for (const problem of problems) {
+		console.error(problem);
+	}
+	process.exit(1);
+}
+console.log(`No unsupported features in ${files.length} built CSS file(s).`);

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -4,7 +4,6 @@ export default {
 		'stylelint-config-standard',
 		'@wordpress/stylelint-config/stylistic',
 	],
-	plugins: ['stylelint-no-unsupported-browser-features'],
 	rules: {
 		'color-function-notation': 'legacy',
 		// The `inset` shorthand needs Chrome 87 / Safari 14.1, above our floor, so
@@ -13,14 +12,6 @@ export default {
 			true,
 			{
 				ignoreShorthands: ['inset'],
-			},
-		],
-		'plugin/no-unsupported-browser-features': [
-			true,
-			{
-				// Caniuse flags css-overflow as partial over `overflow: clip` and
-				// two-value syntax. Plain `overflow-y: auto` is universal.
-				ignore: ['css-sel2', 'css-overflow'],
 			},
 		],
 	},


### PR DESCRIPTION
Ports the approach from marekdedic/dedic.eu#1292 to this repo, and fixes a real defect it uncovered in vendored CSS.

## The problem

Two parts of the compat setup assumed a prefixer that does not exist here:

```
stylelint-config-standard    *-no-vendor-prefix rules       forbid writing prefixes
doiuse/BrowserSelection.js   if (/(^|\s)y($|\s)/.test(...))  skips "y x" (prefixed) support
```

One says *do not write prefixes*, the other says *I will not tell you when you need one*. Nothing added them.

## The real find: vendored `inset`

`node_modules/imagelightbox/dist/imagelightbox.css` was copied into `dist/bundled/` verbatim, and it uses the **`inset` shorthand** — which needs Chrome 87 and Safari 14.1, against this repo's floor of Chrome 66 and Safari 13.

This repo's own `stylelint.config.js` already avoids `inset` for precisely that reason:

> The `inset` shorthand needs Chrome 87 / Safari 14.1, above our floor, so the longhands are deliberate.

But that rule only ever applied to `src/`. The vendored copy shipped the shorthand unprocessed, and no check looked at it. Routing that copy task through Lightning CSS lowers it to longhands.

## The fix

Lightning CSS replaces `gulp-clean-css`, with targets from the existing `browserslist` field, and now also processes the bundled imagelightbox CSS. It minifies as before, and additionally lowers syntax and adds prefixes for the floor.

## Why the check moves to the built output

Because Lightning CSS lowers syntax, source CSS no longer reflects what ships — source-level compat linting would report features already fixed by the time they ship. It also cannot see vendored CSS at all, which is exactly where the `inset` defect was. So `plugin/no-unsupported-browser-features` is removed and the check runs against `dist/`, in a new `check:*` script group wired into CI after Build.

## Suppression is per declaration, not per feature

A feature-level ignore is broader than the reason for it — ignoring a feature to permit one safe value also permits every unsafe one. One entry remains, as a predicate over the flagged declaration:

| feature | what the flag covers | what ships |
|---|---|---|
| `css-overflow` | #1 two-value `overflow` shorthand, #2 the `clip` value | single-value only |

The previous config also ignored `css-sel2`. It produces no finding against the built output, so it is dropped rather than carried over.

## Verification

- `inset: 0` confirmed lowered to longhands in `dist/bundled/imagelightbox.css`
- gate exits **0** clean, **1** on an injected `:has()` rule, **1** with no build present
- eslint and stylelint clean, including `--report-needless-disables`

`scripts/**/*.js` is added to the `lint:ts:eslint` glob so the new script is actually linted, with a `.eslintrc.json` override for `env: node` and `no-console`.
