### PR TITLE
Check the ES version of the built JavaScript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@wordpress/stylelint-config": "^24.2.0",
         "browserslist": "^4.28.8",
         "doiuse": "^6.0.6",
+        "es-check": "^9.6.4",
         "eslint": "^8.57.1",
         "eslint-import-resolver-typescript": "^4.4.5",
         "eslint-plugin-compat": "^6.2.1",
@@ -14500,6 +14501,40 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-check": {
+      "version": "9.6.4",
+      "resolved": "https://registry.npmjs.org/es-check/-/es-check-9.6.4.tgz",
+      "integrity": "sha512-tZq2twJz5EVZk4THqPt9Nm+/EZbwYspus9bs86WLQ6cG08Du75dHB/1ZXyRVGRbeJoxKhsFXNWxCQrOISfuC3w==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "site"
+      ],
+      "dependencies": {
+        "acorn": "8.16.0",
+        "fast-glob": "^3.3.3"
+      },
+      "bin": {
+        "es-check": "lib/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "pnpm": ">=9.0.0"
+      }
+    },
+    "node_modules/es-check/node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/es-define-property": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "test": "run-p -c --aggregate-output test:*",
     "plugin-check": "wp-env start && wp-env run cli wp plugin check skaut-google-drive-gallery --ignore-codes=missing_composer_json_file; CODE=$?; wp-env stop; exit $CODE",
     "check": "run-p -c --aggregate-output check:*",
-    "check:css-compat": "node scripts/check-css-compat.js"
+    "check:css-compat": "node scripts/check-css-compat.js",
+    "check:js-compat": "es-check es2017 --checkFeatures --not 'dist/bundled/imagelightbox.umd.js,dist/bundled/justified-layout.umd.js' 'dist/**/*.js' && es-check es2017 'dist/bundled/justified-layout.umd.js'"
   },
   "engines": {
     "npm": "^8.0.0"
@@ -76,6 +77,7 @@
     "@wordpress/stylelint-config": "^24.2.0",
     "browserslist": "^4.28.8",
     "doiuse": "^6.0.6",
+    "es-check": "^9.6.4",
     "eslint": "^8.57.1",
     "eslint-import-resolver-typescript": "^4.4.5",
     "eslint-plugin-compat": "^6.2.1",


### PR DESCRIPTION
Adds the JavaScript half of the built-artifact checks, alongside the CSS gate from #3279.

## Why the existing checks don't cover this

| check | covers | does not cover |
|---|---|---|
| tsconfig `target` | typechecking | **the emitted syntax** — gulp and Vite emit, so `target` never reaches the output |
| tsconfig `lib` | ES APIs in this repo's own code | dependencies; syntax |
| eslint-plugin-compat | web APIs in **source** | ES syntax; built output; dependencies |

Nothing verifies the syntax that actually ships — exactly where a build step can emit above the declared target with nothing complaining. This estate has already produced two such cases: `plugin-legacy` silently overriding `build.target`, and Lightning CSS merging `overflow` longhands against its own targets (parcel-bundler/lightningcss#1319).

## What was added

`es-check` asserts `es2017` against the built JavaScript, joining the existing `check:*` group — so CI picks it up with **no workflow change**.

`--checkFeatures` extends the check from syntax to ES APIs (`Object.hasOwn`, `[].at()`, `Array.prototype.flat`). Our own four files pass cleanly, so **no ignore list is needed**.

## `dist/bundled/` excluded — and it currently hides a real defect

Those files are copied verbatim from `node_modules`, as in the CSS gate. But unlike the other repos in this series, the exclusion here is covering a genuine break rather than false positives:

```
dist/bundled/imagelightbox.umd.js
  OptionalChaining, NullishCoalescing, globalThis, LogicalAssignment
```

The vendored **imagelightbox 4.0.0** UMD bundle uses optional chaining (Chrome 80, Safari 13.1), nullish coalescing and logical assignment — against this repo's floor of **Chrome 66 / Safari 13**. So the gallery's lightbox is broken on Chrome 66-79 and Safari 13.0 today.

4.0.0 is the latest published version, and its build predates the `es2017` target that `imagelightbox` `master` now carries — the current build there passes `es-check es2017` cleanly. So the fix is a new imagelightbox release plus a dependency bump here, not a change in this repo. Tracked separately.

Excluding `dist/bundled/` keeps the gate green on what this repo controls, rather than blocking on an upstream release.

## Verification

- exits **1** on `?.` injected into a built file, **0** when clean
- eslint clean
