### PR TITLE
Drop obsolete npm engines constraint

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,9 +51,6 @@
     "test:php:phpunit": "vendor/bin/phpunit",
     "posttest:php:phpunit": "composer install"
   },
-  "engines": {
-    "npm": "^8.0.0"
-  },
   "dependencies": {
     "@skaut/justified-layout": "^5.0.0",
     "imagelightbox": "^4.0.0",


### PR DESCRIPTION
Remove the `engines.npm: ^8.0.0` constraint (and the now-empty `engines` block).

It was originally added in #1172 (Dec 2021) to pin **npm 6** as a workaround for a CI break with npm 7's lockfile. It was relaxed to `^8.0.0` in April 2022. The lockfile is now v3 and there is no `node` engine bounding npm here, so the constraint no longer reflects a real requirement — and as written (`^8.0.0` = npm 8.x only) it would actually fail under current npm (10/11) with engine-strict.